### PR TITLE
Feat: Moved WebApp config to docker-compose, added support for https

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ New version of the docker speedtest tool. The components are more decoupled and 
 
 ## Getting Started
 
-First create an environment file (`db.env`) that contains the line `POSTGRES_PASSWORD=<YOUR PASSWORD HERE>`.
-Next you will need to adjust the `API_HOST` variable with the IP address of the machine you want to run the system on in the `webapp/app/config.js` file.
+Create an environment file (`db.env`) that contains the line `POSTGRES_PASSWORD=<YOUR PASSWORD HERE>`.
+You'll likely need to adjust the `docker-compose.yml`, either removing or modifying `API_HOST`, `API_PORT`, and `API_PROTOCOL` depending on your setup.
 
 You can then run the docker compose script:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,9 @@ services:
         restart: always
         ports: 
             - "80:80"
+        environment:
+            API_HOST: "192.168.0.185" # Optional, defaults to the 'hostname' of the webapp e.g. '192.168.1.69', or 'speedtest.domain.com'
+            API_PORT: "7000" # Optional, only needed if you change the above 'speedtest-api' port
+            API_PROTOCOL: "http" # Optional, defaults to the http/https protocol used to access the webapp
         depends_on: 
             - speedtest-api

--- a/webapp/app/components/endpoint.js
+++ b/webapp/app/components/endpoint.js
@@ -4,8 +4,9 @@ const conf = require('../config');
 export default class ApiHandler {
     constructor() {
         // retrieve the api location
-        this.host = conf.API_HOST || "localhost";
+        this.host = conf.API_HOST || window.location.hostname;
         this.port = conf.API_PORT || 7000;
+        this.protocol = conf.API_PROTOCOL || window.location.protocol.replace(":", "");
 
         //console.log("API AT LOCATION: " + this.host + ":" + this.port);
     }
@@ -31,7 +32,7 @@ export default class ApiHandler {
 
     //! Helper that sends a get request to the server
     getContentData(url) {
-        let final_url = "http://" + this.host + ":" + this.port + url;
+        let final_url = `${this.protocol}://${this.host}:${this.port}${url}`;
         let ref = this
         return new Promise(function(resolve, reject) {
             ref._getData(final_url)

--- a/webapp/app/config.js
+++ b/webapp/app/config.js
@@ -1,2 +1,3 @@
-export const API_HOST = "192.168.0.185";
-export const API_PORT = 7000;
+export const API_HOST = window.injectedEnv.API_HOST;
+export const API_PORT = window.injectedEnv.API_PORT;
+export const API_PROTOCOL = window.injectedEnv.API_PROTOCOL;

--- a/webapp/app/env.template.js
+++ b/webapp/app/env.template.js
@@ -1,0 +1,5 @@
+window.injectedEnv = {
+    API_HOST: '${API_HOST}',
+    API_PORT: '${API_PORT}',
+    API_PROTOCOL: '${API_PROTOCOL}',
+};

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -9,6 +9,7 @@
       integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
       crossorigin="anonymous"
     />
+    <script src="/env.js"></script>
     <title>React Speedtester</title>
   </head>
   <body>

--- a/webapp/dockerfile
+++ b/webapp/dockerfile
@@ -16,6 +16,9 @@ RUN npm run build
 
 # production environment
 FROM nginx:stable-alpine
+RUN apk add --no-cache gettext
+COPY ./app/env.template.js /usr/share/nginx/html
+COPY nginx-entrypoint.sh /
 COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 80
-CMD [ "nginx", "-g", "daemon off;" ]
+ENTRYPOINT [ "sh", "/nginx-entrypoint.sh" ]

--- a/webapp/nginx-entrypoint.sh
+++ b/webapp/nginx-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+WWW_DIR=/usr/share/nginx/html
+
+INJECT_FILE_SRC="${WWW_DIR}/env.template.js"
+INJECT_FILE_DST="${WWW_DIR}/env.js"
+
+envsubst < "${INJECT_FILE_SRC}" > "${INJECT_FILE_DST}"
+
+[ -z "$@" ] && nginx -g 'daemon off;' || $@


### PR DESCRIPTION
## Proposed Changes

  - Changed the default `host` & `port` for the WebAPI in `webapp/app/components/endpoint.js` to point to the same hostname used to call the WebApp. This simplifies everything for 99% of use cases, doesn't require env variables to be set.
  - Added a `protocol` variable in `webapp/app/components/endpoint.js` to explicitly set `http OR https` vs how it was previously `http` only. This also defaults to the protocol used to call the WebApp, increases compatibility for things like reverse proxies.
  - Moves the need to update `webapp/app/config.js` with server IP & Port to `docker-compose.yml`, and adds the option for protocol. This is used in conjunction with the new `nginx-entrypoint.sh` script that is used to "bootstrap" the Docker Compose env's into a JS file, then starts the `nginx` server like normal. Allows more "exotic" configurations to be possible, while having to update the least amount of files